### PR TITLE
Added buffered rolling file appender classes and associated unit tests

### DIFF
--- a/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
@@ -1,0 +1,2 @@
+package com.yscope.logging.log4j1;public class AbstractBufferedRollingFileAppender {
+}

--- a/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
@@ -1,0 +1,121 @@
+package com.yscope.logging.log4j1;
+
+import org.apache.log4j.spi.LoggingEvent;
+
+import java.io.IOException;
+
+/**
+ * This abstract class extends {@code AbstractBufferedRollingFileAppender} with
+ * buffered CLP streaming log compression functionality
+ */
+public abstract class AbstractClpBufferedRollingFileAppender
+        extends AbstractBufferedRollingFileAppender
+{
+    // File size based rollover strategy for streaming compressed logging is
+    // governed by both the compressed on-disk size and the size of raw
+    // uncompressed content. The former is to ensure a reasonable local and/or
+    // remote file size to reduce both the file system overhead and cost during
+    // log generation, synchronization with remote log store, accessing and
+    // searching the compressed log file at a later time. The uncompressed size
+    // is also used to ensure that compressed log files when decompressed back
+    // to its original content be opened efficiently by file editors.
+    private long compressedRolloverSize = 16 * 1024 * 1024;
+    private long compressedSizeSinceLastRollover = 0L;
+
+    private long uncompressedRolloverSize = 2L * 1024 * 1024 * 1024;
+    private long uncompressedSizeSinceLastRollover = 0L;
+
+    // CLP streaming compression parameters
+    private int compressionLevel = 3;
+    private boolean closeFrameOnFlush = true;
+    private boolean useCompactEncoding = false;
+
+    protected String baseName;
+    protected ClpIrFileAppender clpIrFileAppender = null;
+    protected String currentFileName;
+    protected String outputDir;
+
+    public static final String CLP_COMPRESSED_IRSTREAM_FILE_EXTENSION = ".clp.zst";
+
+    public void setCompressedRolloverSize(long compressedRolloverSize) {
+        this.compressedRolloverSize = compressedRolloverSize;
+    }
+
+    public void setUncompressedRolloverSize(long uncompressedRolloverSize) {
+        this.uncompressedRolloverSize = uncompressedRolloverSize;
+    }
+
+    public void setUseCompactEncoding(boolean useCompactEncoding) {
+        this.useCompactEncoding = useCompactEncoding;
+    }
+
+    public void setOutputDir(String outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    public void setBaseName(String baseName) {
+        this.baseName = baseName;
+    }
+
+    public long getUncompressedSize() {
+        return uncompressedSizeSinceLastRollover + clpIrFileAppender.getUncompressedSize();
+    }
+
+    public long getCompressedSize() {
+        return compressedSizeSinceLastRollover + clpIrFileAppender.getCompressedSize();
+    }
+
+    @Override
+    public void activateOptions() {
+        super.activateOptions();
+        try {
+            clpIrFileAppender = new ClpIrFileAppender(currentLogPath, layout, useCompactEncoding,
+                    closeFrameOnFlush, compressionLevel);
+        } catch (IOException e) {
+            logError("Failed to activate appender", e);
+        }
+    }
+
+    @Override
+    public void appendBufferedFile(LoggingEvent loggingEvent) {
+        clpIrFileAppender.append(loggingEvent);
+    }
+
+    @Override
+    protected boolean rolloverRequired() {
+        return getCompressedSize() > compressedRolloverSize ||
+                getUncompressedSize() > uncompressedRolloverSize;
+    }
+
+    @Override
+    protected void closeOldBufferedFile() {
+        clpIrFileAppender.close();
+        compressedRolloverSize += clpIrFileAppender.getCompressedSize();
+        uncompressedSizeSinceLastRollover += clpIrFileAppender.getUncompressedSize();
+    }
+
+    protected void updateLogFileName() {
+        currentFileName = baseName + "." + lastRolloverTimestamp
+                + CLP_COMPRESSED_IRSTREAM_FILE_EXTENSION;
+    }
+
+    @Override
+    protected void updateLogFilePath() {
+        updateLogFileName();
+        currentLogPath = outputDir = "/" + currentFileName;
+    }
+
+    @Override
+    protected void startNewBufferedFile() {
+        try {
+            clpIrFileAppender.startNewFile(currentLogPath);
+        } catch (IOException e) {
+            logError("Failed to start new buffered file", e);
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        clpIrFileAppender.flush();
+    }
+}

--- a/src/test/java/com/yscope/logging/log4j1/RollingFileAppenderTestHarness.java
+++ b/src/test/java/com/yscope/logging/log4j1/RollingFileAppenderTestHarness.java
@@ -1,0 +1,28 @@
+package com.yscope.logging.log4j1;
+
+public class ClpIrBufferedRollingFileAppenderTestHarness extends AbstractClpIrBufferedRollingFileAppender{
+    private int numSyncEvent = 0;
+    private int numSyncAndCloseEvent = 0;
+
+    /**
+     * We hook onto the sync function to record flush and close events
+     * @param path of log file on the local file system
+     * @param deleteFile whenever the implementation sees fit
+     */
+    @Override
+    protected synchronized void sync(String path, boolean deleteFile) {
+        if (deleteFile) {
+            numSyncAndCloseEvent += 1;
+        } else {
+            numSyncEvent += 1;
+        }
+    }
+
+    public synchronized int getNumSyncAndCloseEvent() {
+        return numSyncAndCloseEvent;
+    }
+
+    public synchronized int getNumSyncEvent() {
+        return numSyncEvent;
+    }
+}

--- a/src/test/java/com/yscope/logging/log4j1/TestFileAppender.java
+++ b/src/test/java/com/yscope/logging/log4j1/TestFileAppender.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class TestAppender {
+public class TestClpIrFileAppender {
   private final String patternLayoutString = "%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n";
   private final PatternLayout patternLayout = new PatternLayout(patternLayoutString);
   private final int compressionLevel = 3;
@@ -58,7 +58,6 @@ public class TestAppender {
                                                     false, Integer.MAX_VALUE));
 
     // Validate different file paths
-    ClpIrFileAppender clpIrFileAppender;
     try {
       testEmptyCreation(Paths.get(fileName), patternLayout, useFourByteEncoding);
       testEmptyCreation(Paths.get("a", "b", fileName), patternLayout, useFourByteEncoding);
@@ -165,7 +164,7 @@ public class TestAppender {
     //  should all be verified by a decoding the stream and comparing it with
     //  the output of an uncompressed file appender.
 
-    Logger logger = Logger.getLogger(TestAppender.class);
+    Logger logger = Logger.getLogger(TestClpIrFileAppender.class);
     String message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
 
     ClpIrFileAppender clpIrFileAppender = new ClpIrFileAppender(fileName, patternLayout,

--- a/src/test/java/com/yscope/logging/log4j1/TestRollingFileLogAppender.java
+++ b/src/test/java/com/yscope/logging/log4j1/TestRollingFileLogAppender.java
@@ -1,0 +1,180 @@
+package com.yscope.logging.log4j1;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestRollingLogAppender {
+    private Logger logger = Logger.getLogger(TestFileAppender.class);
+
+    private final String patternLayoutString = "%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n";
+    private final PatternLayout patternLayout = new PatternLayout(patternLayoutString);
+    private final String outputDir = "testOutputDir";
+    private final String baseName = "test-file";
+
+    /**
+     * Testing uncompressed size rollover is very simple. We shrink the
+     * uncompressed roll-over size to 1 byte will shall trigger one sync and
+     * close event for every new log event appended by the appender.
+     */
+    @Test
+    public void testRollingBasedOnUncompressedSize() {
+        RollingFileAppenderTestHarness clpIrRollingLocalFileAppender =
+                generateTestAppender(99999999, 1);
+
+        // Append the 1st message and expect rollover to a new file
+        appendLogEvent(clpIrRollingLocalFileAppender);
+        checkNumSyncAndCloseEvent(clpIrRollingLocalFileAppender, 1, 1000);
+
+        // Append the 2nd message and expect rollover to a new file
+        appendLogEvent(clpIrRollingLocalFileAppender);
+        checkNumSyncAndCloseEvent(clpIrRollingLocalFileAppender, 2, 1000);
+
+        // Close the appender should sync and close the current opened file
+        clpIrRollingLocalFileAppender.close();
+        checkNumSyncAndCloseEvent(clpIrRollingLocalFileAppender, 3, 1000);
+
+        teardown();
+    }
+
+    /**
+     * Testing compressed size rollover is harder than uncompressed size
+     * because we do not know the compressed file size prior to flushing the
+     * compression buffer. Rollover also occurs synchronously within the append
+     * method of the appender, thus we need to first append something prior
+     * triggering the rollover on the next append operation.
+     */
+    @Test
+    public void testRollingBasedOnCompressedSize() throws InterruptedException, IOException {
+        RollingFileAppenderTestHarness clpIrRollingLocalFileAppender =
+                generateTestAppender(1, 9999999);
+
+        // Append the first message, and force manual flush so the next append
+        // shall trigger a rollover event
+        appendLogEvent(clpIrRollingLocalFileAppender);
+        clpIrRollingLocalFileAppender.flush();   // Trigger flush
+        checkNumSyncAndCloseEvent(clpIrRollingLocalFileAppender, 0, 1000);
+        appendLogEvent(clpIrRollingLocalFileAppender);
+        checkNumSyncAndCloseEvent(clpIrRollingLocalFileAppender, 1, 1000);
+
+        // Since a file rollover event should have occurred, closing the
+        // appender shall close the current empty file
+        clpIrRollingLocalFileAppender.close();
+        checkNumSyncAndCloseEvent(clpIrRollingLocalFileAppender, 2, 1000);
+
+        teardown();
+    }
+
+    /**
+     * Testing hard timeout is fairly simple by explicitly setting the hard
+     * timeout epoch value to the past.
+     */
+    @Test
+    public void testHardTimeout() {
+        RollingFileAppenderTestHarness clpIrRollingLocalFileAppender =
+                generateTestAppender(99999999, 99999999);
+
+        // Append a log event then explicitly set hard deadline epoch to the past.
+        // The background flusher shall flush the log event asychronously shortly
+        appendLogEvent(clpIrRollingLocalFileAppender);
+        clpIrRollingLocalFileAppender.setHardFlushTimeoutEpoch(System.currentTimeMillis() - 999);
+        checkNumSyncEvent(clpIrRollingLocalFileAppender, 1, 1000);
+        checkNumSyncAndCloseEvent(clpIrRollingLocalFileAppender, 0, 1000);
+
+        // After closing the file appender, we should have 1 close/delete event
+        clpIrRollingLocalFileAppender.close();
+        checkNumSyncAndCloseEvent(clpIrRollingLocalFileAppender, 1, 1000);
+
+        teardown();
+    }
+
+    /**
+     * Testing soft timeout requires us to append multiple log messages in quick
+     * succession and wait until the soft timeout is triggered
+     * @throws InterruptedException
+     */
+    @Test
+    public void testSoftTimeout() throws InterruptedException {
+        RollingFileAppenderTestHarness clpIrRollingLocalFileAppender =
+                generateTestAppender(99999999, 99999999);
+
+        // Hard deadline should be in distant future
+        clpIrRollingLocalFileAppender.setHardFlushTimeoutEpoch(System.currentTimeMillis() + 99999999);
+
+        // We should observe 3 flush events
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                appendLogEvent(clpIrRollingLocalFileAppender);
+            }
+            clpIrRollingLocalFileAppender.setSoftFlushTimeoutEpoch(System.currentTimeMillis() - 999);
+            checkNumSyncEvent(clpIrRollingLocalFileAppender, i + 1, 1000);
+        }
+
+        // After closing the file appender, we should have 1 flush + close event
+        clpIrRollingLocalFileAppender.close();
+        checkNumSyncAndCloseEvent(clpIrRollingLocalFileAppender, 1, 1000);
+
+        teardown();
+    }
+
+    private RollingFileAppenderTestHarness generateTestAppender(
+            int compressedRolloverSize, int uncompressedRolloverSize)
+    {
+        RollingFileAppenderTestHarness clpIrRollingLocalFileAppender =
+                new RollingFileAppenderTestHarness();
+        // Parameters from {@code AbstractClpIrBufferedRollingFileAppender}
+        clpIrRollingLocalFileAppender.setCompressedRolloverSize(compressedRolloverSize);
+        clpIrRollingLocalFileAppender.setUncompressedRolloverSize(uncompressedRolloverSize);
+        clpIrRollingLocalFileAppender.setOutputDir(outputDir);
+        clpIrRollingLocalFileAppender.setBaseName(baseName);
+        clpIrRollingLocalFileAppender.setCloseFrameOnFlush(true);
+        clpIrRollingLocalFileAppender.setUseCompactEncoding(true);
+        // Parameters from {@code AbstractBufferedRollingFileAppender}
+        clpIrRollingLocalFileAppender.setCloseFileOnShutdown(true);
+        clpIrRollingLocalFileAppender.setLayout(patternLayout);
+        clpIrRollingLocalFileAppender.setBackgroundSyncSleepTimeMs(10);
+
+        clpIrRollingLocalFileAppender.activateOptions();
+        return clpIrRollingLocalFileAppender;
+    }
+
+    private void appendLogEvent(RollingFileAppenderTestHarness appender) {
+        String loggerName = TestFileAppender.class.getCanonicalName();
+        String message = "Static text, dictVar1, 123, 456.7, dictVar2, 987, 654.3";
+        appender.append(new LoggingEvent(loggerName, logger, Level.INFO, message, null));
+    }
+
+    private void checkNumSyncAndCloseEvent(RollingFileAppenderTestHarness appender,
+                                           int numSyncAndCloseEvent, int timeoutMs)
+    {
+        long timeout = System.currentTimeMillis() + timeoutMs;
+        while (appender.getNumSyncAndCloseEvent() != numSyncAndCloseEvent) {
+            if (System.currentTimeMillis() > timeout) {
+                fail();
+            }
+        }
+    }
+
+    private void checkNumSyncEvent(RollingFileAppenderTestHarness appender,
+                                   int numSyncEvent, int timeoutMs)
+    {
+        long timeout = System.currentTimeMillis() + timeoutMs;
+        while (appender.getNumSyncEvent() != numSyncEvent) {
+            if (System.currentTimeMillis() > timeout) {
+                fail();
+            }
+        }
+    }
+
+    private void teardown() {
+        Arrays.stream(new File(outputDir).listFiles()).forEach(File::delete);
+    }
+}


### PR DESCRIPTION
# Description
Initial implementation of two rolling file appender abstract classes: `AbstractBufferedRollingFileAppender` and `AbstractClpIrBufferedRollingFileAppender`.


# Validation performed
- Validated unit tests passes
- Installed the package and used a test program to write some logs.
- Validated that the logs could be decoded by our closed-source IR stream decoders.

