### PR TITLE
Update to clp-ffi:0.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>com.yscope.clp</groupId>
       <artifactId>clp-ffi</artifactId>
-      <version>0.3</version>
+      <version>0.3.1</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
y-scope/clp-ffi-java#24

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
y-scope/clp-ffi-java#24 meant the appenders couldn't be used on several current versions of Linux, so this PR updates to clp-ffi-java to include the bug-fix.

# Validation performed
<!-- What tests and validation you performed on the change -->
Validated that unit tests could be run on Ubuntu 20.04.
