### PR TITLE
Refactored out `createOutputFile` method out of `ClpIrFileAppender` into `Utils`

### DIFF
--- a/src/main/java/com/yscope/logging/log4j1/ClpIrFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/ClpIrFileAppender.java
@@ -1,16 +1,12 @@
 package com.yscope.logging.log4j1;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.Flushable;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 
 import com.github.luben.zstd.Zstd;
@@ -27,6 +23,8 @@ import org.apache.log4j.SimpleLayout;
 import org.apache.log4j.spi.ErrorCode;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.xml.XMLLayout;
+
+import static com.yscope.logging.log4j1.Utils.createOutputFile;
 
 /**
  * A Log4j appender that writes log events into a Zstandard-compressed CLP IR
@@ -422,29 +420,5 @@ public class ClpIrFileAppender extends EnhancedAppenderSkeleton implements Flush
 
     uncompressedSizeInBytes += timestampPattern.getBytes(StandardCharsets.ISO_8859_1).length;
     uncompressedSizeInBytes += timeZoneId.length();
-  }
-
-  /**
-   * Creates and opens the output file and file output stream.
-   * @param filePath
-   * @return The file output stream
-   * @throws IOException on I/O error
-   */
-  private FileOutputStream createOutputFile (String filePath) throws IOException {
-    FileOutputStream fileOutputStream;
-    try {
-      // append = false since we don't support appending to an existing file
-      fileOutputStream = new FileOutputStream(filePath, false);
-    } catch (FileNotFoundException ex) {
-      // Create the parent directory if necessary
-      String parentPath = new File(filePath).getParent();
-      if (null == parentPath) {
-        throw ex;
-      }
-      Files.createDirectories(Paths.get(parentPath));
-
-      fileOutputStream = new FileOutputStream(filePath, false);
-    }
-    return fileOutputStream;
   }
 }

--- a/src/main/java/com/yscope/logging/log4j1/Utils.java
+++ b/src/main/java/com/yscope/logging/log4j1/Utils.java
@@ -13,7 +13,7 @@ import org.apache.log4j.Layout;
 
 public class Utils {
   /**
-   * Creates and opens the output file and file output stream.
+   * Creates and opens an output file and file output stream.
    * @param filePath
    * @return The file output stream
    * @throws IOException on I/O error

--- a/src/main/java/com/yscope/logging/log4j1/Utils.java
+++ b/src/main/java/com/yscope/logging/log4j1/Utils.java
@@ -1,12 +1,41 @@
 package com.yscope.logging.log4j1;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.log4j.Layout;
 
 public class Utils {
+  /**
+   * Creates and opens the output file and file output stream.
+   * @param filePath
+   * @return The file output stream
+   * @throws IOException on I/O error
+   */
+  public static FileOutputStream createOutputFile (String filePath) throws IOException {
+    FileOutputStream fileOutputStream;
+    try {
+      // append = false since we don't support appending to an existing file
+      fileOutputStream = new FileOutputStream(filePath, false);
+    } catch (FileNotFoundException ex) {
+      // Create the parent directory if necessary
+      String parentPath = new File(filePath).getParent();
+      if (null == parentPath) {
+        throw ex;
+      }
+      Files.createDirectories(Paths.get(parentPath));
+
+      fileOutputStream = new FileOutputStream(filePath, false);
+    }
+    return fileOutputStream;
+  }
+
   /**
    * Writes the given throwable's string representation to the given output
    * stream


### PR DESCRIPTION
# Description
`createOutputFile` method in `ClpIrFileAppender` can be re-used in many places in log appender. This method is now refactored out into `Utils` class.
