### PR TITLE
Reduced uncompressed size rollover limit from 2GB to 1GB.

### DIFF
--- a/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
@@ -33,7 +33,7 @@ public abstract class AbstractClpIrBufferedRollingFileAppender
   private boolean closeFrameOnFlush = true;
   private boolean useFourByteEncoding = false;
   private long rolloverCompressedSizeThreshold = 16 * 1024 * 1024;  // Bytes
-  private long rolloverUncompressedSizeThreshold = 2L * 1024 * 1024 * 1024;  // Bytes
+  private long rolloverUncompressedSizeThreshold = 1024L * 1024 * 1024;  // Bytes
 
   private long compressedSizeSinceLastRollover = 0L;  // Bytes
   private long uncompressedSizeSinceLastRollover = 0L;  // Bytes


### PR DESCRIPTION
# References
Reduced uncompressed size rollover limit from 2GB to 1GB. This helps with performance of loading compressed logs into the UI.
