### PR TITLE
Add compressedLogSize, uncompressedLogSize and logEventIdx metadata to every file synchronization request.

### DIFF
--- a/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
@@ -79,6 +79,8 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
   private final BackgroundFlushThread backgroundFlushThread = new BackgroundFlushThread();
   private final BackgroundSyncThread backgroundSyncThread = new BackgroundSyncThread();
 
+  private long logEventIdx = 1L;
+
   private boolean activated = false;
 
   /**
@@ -194,6 +196,10 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
     return baseName;
   }
 
+  public long getLogEventIdx () {
+    return logEventIdx;
+  }
+
   /**
    * Activates the appender's options.
    * <p></p>
@@ -286,6 +292,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
   public final synchronized void append (LoggingEvent loggingEvent) {
     try {
       appendHook(loggingEvent);
+      ++logEventIdx;
 
       if (false == rolloverRequired()) {
         updateFreshnessTimeouts(loggingEvent);
@@ -295,6 +302,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
         resetFreshnessTimeouts();
         lastRolloverTimestamp = loggingEvent.getTimeStamp();
         startNewLogFile(lastRolloverTimestamp);
+        logEventIdx = 1L;
       }
     } catch (Exception ex) {
       getErrorHandler().error("Failed to write log event.", ex, ErrorCode.WRITE_FAILURE);

--- a/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
@@ -79,7 +79,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
   private final BackgroundFlushThread backgroundFlushThread = new BackgroundFlushThread();
   private final BackgroundSyncThread backgroundSyncThread = new BackgroundSyncThread();
 
-  private long numEventLogged = 0L;
+  private long numEventsLogged = 0L;
 
   private boolean activated = false;
 
@@ -196,8 +196,8 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
     return baseName;
   }
 
-  public long getNumEventLogged () {
-    return numEventLogged;
+  public long getNumEventsLogged () {
+    return numEventsLogged;
   }
 
   /**
@@ -292,7 +292,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
   public final synchronized void append (LoggingEvent loggingEvent) {
     try {
       appendHook(loggingEvent);
-      ++numEventLogged;
+      ++numEventsLogged;
 
       if (false == rolloverRequired()) {
         updateFreshnessTimeouts(loggingEvent);
@@ -302,7 +302,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
         resetFreshnessTimeouts();
         lastRolloverTimestamp = loggingEvent.getTimeStamp();
         startNewLogFile(lastRolloverTimestamp);
-        numEventLogged = 0L;
+        numEventsLogged = 0L;
       }
     } catch (Exception ex) {
       getErrorHandler().error("Failed to write log event.", ex, ErrorCode.WRITE_FAILURE);

--- a/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
@@ -3,6 +3,7 @@ package com.yscope.logging.log4j1;
 import java.io.Flushable;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.apache.log4j.Level;
@@ -357,6 +358,14 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
   protected abstract String computeLogFileName (String baseName, long logRolloverTimestamp);
 
   /**
+   * Computes the metadata which will be included in a synchronization request
+   * @return The computed metadata map
+   */
+  protected Map<String, Object> computeSyncRequestMetadata () {
+    return new HashMap<>();
+  }
+
+  /**
    * Tests if log level is supported by this appender configuration
    * @param level string passed in from configuration parameter
    * @return true if supported, false otherwise
@@ -504,11 +513,13 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
       public final String logFileBaseName;
       public final long logRolloverTimestamp;
       public final boolean deleteFile;
+      public final Map<String, Object> metadata;
 
       public SyncRequest (String logFileBaseName, long logRolloverTimestamp, boolean deleteFile) {
         this.logFileBaseName = logFileBaseName;
         this.logRolloverTimestamp = logRolloverTimestamp;
         this.deleteFile = deleteFile;
+        this.metadata = computeSyncRequestMetadata();
       }
     }
   }

--- a/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
@@ -79,7 +79,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
   private final BackgroundFlushThread backgroundFlushThread = new BackgroundFlushThread();
   private final BackgroundSyncThread backgroundSyncThread = new BackgroundSyncThread();
 
-  private long logEventIdx = 1L;
+  private long numEventLogged = 0L;
 
   private boolean activated = false;
 
@@ -196,8 +196,8 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
     return baseName;
   }
 
-  public long getLogEventIdx () {
-    return logEventIdx;
+  public long getNumEventLogged () {
+    return numEventLogged;
   }
 
   /**
@@ -292,7 +292,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
   public final synchronized void append (LoggingEvent loggingEvent) {
     try {
       appendHook(loggingEvent);
-      ++logEventIdx;
+      ++numEventLogged;
 
       if (false == rolloverRequired()) {
         updateFreshnessTimeouts(loggingEvent);
@@ -302,7 +302,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
         resetFreshnessTimeouts();
         lastRolloverTimestamp = loggingEvent.getTimeStamp();
         startNewLogFile(lastRolloverTimestamp);
-        logEventIdx = 1L;
+        numEventLogged = 0L;
       }
     } catch (Exception ex) {
       getErrorHandler().error("Failed to write log event.", ex, ErrorCode.WRITE_FAILURE);

--- a/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
@@ -365,7 +365,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
    * @return The computed metadata map
    */
   protected Map<String, Object> computeSyncRequestMetadata () {
-    return new HashMap<>();
+    return null;
   }
 
   /**

--- a/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
@@ -27,8 +27,6 @@ public abstract class AbstractClpIrBufferedRollingFileAppender
 {
   public static final String CLP_COMPRESSED_IRSTREAM_FILE_EXTENSION = ".clp.zst";
 
-  protected long logEventIdx = 1L;
-
   // Appender settings, some of which may be set by Log4j through reflection.
   // For descriptions of the properties, see their setters below.
   private String outputDir;
@@ -121,6 +119,10 @@ public abstract class AbstractClpIrBufferedRollingFileAppender
     return compressedSizeSinceLastRollover + clpIrFileAppender.getCompressedSize();
   }
 
+  public int getCompressionLevel () {
+    return compressionLevel;
+  }
+
   @Override
   public void activateOptionsHook (long currentTimestamp) throws IOException {
     String fileName = computeLogFileName(getBaseName(), currentTimestamp);
@@ -162,9 +164,9 @@ public abstract class AbstractClpIrBufferedRollingFileAppender
   @Override
   protected Map<String, Object> computeSyncRequestMetadata () {
     Map<String, Object> metadata = new HashMap<>();
-    metadata.put("compressedLogSize", getCompressedSize());
-    metadata.put("uncompressedLogSize", getUncompressedSize());
-    metadata.put("logEventIdx", logEventIdx);
+    metadata.put("compressedLogSize", clpIrFileAppender.getCompressedSize());
+    metadata.put("uncompressedLogSize", clpIrFileAppender.getUncompressedSize());
+    metadata.put("logEventIdx", getLogEventIdx());
     return metadata;
   }
 

--- a/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
@@ -166,7 +166,7 @@ public abstract class AbstractClpIrBufferedRollingFileAppender
     Map<String, Object> metadata = new HashMap<>();
     metadata.put("compressedLogSize", clpIrFileAppender.getCompressedSize());
     metadata.put("uncompressedLogSize", clpIrFileAppender.getUncompressedSize());
-    metadata.put("numEventLogged", getNumEventLogged());
+    metadata.put("numEventsLogged", getNumEventsLogged());
     return metadata;
   }
 

--- a/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
@@ -2,6 +2,8 @@ package com.yscope.logging.log4j1;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.log4j.spi.LoggingEvent;
 
@@ -24,6 +26,8 @@ public abstract class AbstractClpIrBufferedRollingFileAppender
     extends AbstractBufferedRollingFileAppender
 {
   public static final String CLP_COMPRESSED_IRSTREAM_FILE_EXTENSION = ".clp.zst";
+
+  protected long logEventIdx = 1L;
 
   // Appender settings, some of which may be set by Log4j through reflection.
   // For descriptions of the properties, see their setters below.
@@ -153,6 +157,15 @@ public abstract class AbstractClpIrBufferedRollingFileAppender
   @Override
   public void flush () throws IOException {
     clpIrFileAppender.flush();
+  }
+
+  @Override
+  protected Map<String, Object> computeSyncRequestMetadata () {
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("compressedLogSize", getCompressedSize());
+    metadata.put("uncompressedLogSize", getUncompressedSize());
+    metadata.put("logEventIdx", logEventIdx);
+    return metadata;
   }
 
   @Override

--- a/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractClpIrBufferedRollingFileAppender.java
@@ -166,7 +166,7 @@ public abstract class AbstractClpIrBufferedRollingFileAppender
     Map<String, Object> metadata = new HashMap<>();
     metadata.put("compressedLogSize", clpIrFileAppender.getCompressedSize());
     metadata.put("uncompressedLogSize", clpIrFileAppender.getUncompressedSize());
-    metadata.put("logEventIdx", getLogEventIdx());
+    metadata.put("numEventLogged", getNumEventLogged());
     return metadata;
   }
 

--- a/src/test/java/com/yscope/logging/log4j1/RollingFileTestAppender.java
+++ b/src/test/java/com/yscope/logging/log4j1/RollingFileTestAppender.java
@@ -1,5 +1,7 @@
 package com.yscope.logging.log4j1;
 
+import java.util.Map;
+
 /**
  * A rolling file appender used for testing
  * {@link AbstractClpIrBufferedRollingFileAppender}. It specifically allows us
@@ -35,10 +37,11 @@ public class RollingFileTestAppender extends AbstractClpIrBufferedRollingFileApp
    * @param baseName {@inheritDoc}
    * @param logRolloverTimestamp {@inheritDoc}
    * @param deleteFile {@inheritDoc}
+   * @param fileMetadata {@inheritDoc}
    */
   @Override
   protected synchronized void sync (String baseName, long logRolloverTimestamp,
-                                    boolean deleteFile)
+                                    boolean deleteFile, Map<String, Object> fileMetadata)
   {
     if (deleteFile) {
       numRollovers += 1;


### PR DESCRIPTION
# Description
During processing of asynchronous file synchronization requests, custom metadata may be gathered at the time of submitting the synchronization request to make decisions. This commit enables the functionality to allow downstream appenders to customize the metadata that is included with every synchronization request.

# Validation performed
All existing unit tests passed.

