### PR TITLE
AbstractBufferredRollingFileAppender: Rework the flush and sync logic when the appender is closed (fixes #19).

### DIFF
--- a/src/test/java/com/yscope/logging/log4j1/TestRollingFileLogAppender.java
+++ b/src/test/java/com/yscope/logging/log4j1/TestRollingFileLogAppender.java
@@ -226,9 +226,10 @@ public class TestRollingFileLogAppender {
   }
 
   /**
-   * Performs basic validation of flush timeout support (not specific to either soft/hard) for the
-   * appender
-   * @param testSoftTimeout Whether to test soft (true) or hard (false) timeout support
+   * Performs basic validation of flush timeout support (not specific to either
+   * soft/hard) for the appender
+   * @param testSoftTimeout Whether to test soft (true) or hard (false) timeout
+   * support
    */
   private void validateBasicFlushTimeoutSupport (boolean testSoftTimeout) {
     int timeoutUnitInMilliseconds =


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->
#19


# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
There were several issues with the flush & sync logic on close:
* The background threads weren't daemons.
* The `BackgroundFlushThread` was never interrupted, so it continued running even when `closeFileOnShutdown` was true.
* Several parts of the code treated `InterruptedException` as if it would be received when the JVM was shutting down, but that's not true.

This PR solves the issues:
* The threads are now daemons. When `closeFileOnShutdown` is true and the JVM is shutting down, the threads will continue flushing & syncing logs since daemon threads continue to run during the execution of shutdown hooks.
* They are interrupted as necessary.
* Erroneous uses of InterruptedException are removed.
* New unit tests added to test the flush & sync logic when the appender is closed.

# Validation performed
<!-- What tests and validation you performed on the change -->
Validated new and old unit tests passed
