### PR TITLE
Handle log events whose verbosity does not have a predefined hard or soft flush timeout

### DIFF
--- a/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
@@ -204,7 +204,7 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
    * Sets the per-log-level soft timeouts for flushing.
    * <p>
    * NOTE: Timeouts for custom log-levels are not supported. Log events with
-   *    * these levels will be assigned the timeout of the INFO level.
+   * these levels will be assigned the timeout of the INFO level.
    * @param csvTimeouts A CSV string of kv-pairs. The key being the log-level in
    * all caps and the value being the soft timeout for flushing in seconds. E.g.
    * "INFO=180,WARN=15,ERROR=10"

--- a/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
@@ -514,11 +514,14 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
    */
   private void updateFreshnessTimeouts (LoggingEvent loggingEvent) {
     Level level = loggingEvent.getLevel();
-    long timeoutTimestamp = loggingEvent.timeStamp + flushHardTimeoutPerLevel.get(level);
+    long flushHardTimeout = flushHardTimeoutPerLevel.computeIfAbsent(level,
+            v -> flushHardTimeoutPerLevel.get(Level.INFO));
+    long timeoutTimestamp = loggingEvent.timeStamp + flushHardTimeout;
     flushHardTimeoutTimestamp = Math.min(flushHardTimeoutTimestamp, timeoutTimestamp);
 
-    flushMaximumSoftTimeout = Math.min(flushMaximumSoftTimeout,
-                                       flushSoftTimeoutPerLevel.get(level));
+    long flushSoftTimeout = flushSoftTimeoutPerLevel.computeIfAbsent(level,
+            v -> flushSoftTimeoutPerLevel.get(Level.INFO));
+    flushMaximumSoftTimeout = Math.min(flushMaximumSoftTimeout, flushSoftTimeout);
     flushSoftTimeoutTimestamp = loggingEvent.timeStamp + flushMaximumSoftTimeout;
   }
 

--- a/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
+++ b/src/main/java/com/yscope/logging/log4j1/AbstractBufferedRollingFileAppender.java
@@ -176,6 +176,9 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
 
   /**
    * Sets the per-log-level hard timeouts for flushing.
+   * <p>
+   * NOTE: Timeouts for custom log-levels are not supported. Log events with
+   * these levels will be assigned the timeout of the INFO level.
    * @param csvTimeouts A CSV string of kv-pairs. The key being the log-level in
    * all caps and the value being the hard timeout for flushing in minutes. E.g.
    * "INFO=30,WARN=10,ERROR=5"
@@ -199,6 +202,9 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
 
   /**
    * Sets the per-log-level soft timeouts for flushing.
+   * <p>
+   * NOTE: Timeouts for custom log-levels are not supported. Log events with
+   *    * these levels will be assigned the timeout of the INFO level.
    * @param csvTimeouts A CSV string of kv-pairs. The key being the log-level in
    * all caps and the value being the soft timeout for flushing in seconds. E.g.
    * "INFO=180,WARN=15,ERROR=10"
@@ -515,12 +521,12 @@ public abstract class AbstractBufferedRollingFileAppender extends EnhancedAppend
   private void updateFreshnessTimeouts (LoggingEvent loggingEvent) {
     Level level = loggingEvent.getLevel();
     long flushHardTimeout = flushHardTimeoutPerLevel.computeIfAbsent(level,
-            v -> flushHardTimeoutPerLevel.get(Level.INFO));
+        v -> flushHardTimeoutPerLevel.get(Level.INFO));
     long timeoutTimestamp = loggingEvent.timeStamp + flushHardTimeout;
     flushHardTimeoutTimestamp = Math.min(flushHardTimeoutTimestamp, timeoutTimestamp);
 
     long flushSoftTimeout = flushSoftTimeoutPerLevel.computeIfAbsent(level,
-            v -> flushSoftTimeoutPerLevel.get(Level.INFO));
+        v -> flushSoftTimeoutPerLevel.get(Level.INFO));
     flushMaximumSoftTimeout = Math.min(flushMaximumSoftTimeout, flushSoftTimeout);
     flushSoftTimeoutTimestamp = loggingEvent.timeStamp + flushMaximumSoftTimeout;
   }


### PR DESCRIPTION
# Description
When freshness timeout is computed on every append operation in `AbstractBufferedRollingLogAppender`, if a log event whose verbosity does not contain a corresponding pre-defined hard or soft timeout value is encountered, a NullPointerException is raised. This PR resolves this NullPointerException issue by computing a default timeout value based the INFO verbosity level's timeout value. 

# Validation performed
* Added new unit tests.

